### PR TITLE
Add error handling for estimate button

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -42,7 +42,7 @@
             <select class="travel-input select-destination" name="destinations" id=destinationInput required>
               <option value="All Locations">All Locations:</option>
             </select>
-            <label for="numberOfDays">Duration:</label>
+            <label for="numberOfDays">Duration/Days:</label>
             <input class="travel-input" type="number" name="duration" id="numberOfDays" min="1" max="90" placeholder="# of days" required></input>
             <label for="numberOfTravelers">Travelers:</label>
               <input class="travel-input" type="number" name="numberOfTravelers" id="numberOfTravelers" min="1" max="10" placeholder="# of travelers" required></input>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -148,11 +148,13 @@ const getEstimate = (e) => {
   const possibleTrip = new Trip(obj)
   possibleTrip.instantiateDestination(travelRepository)
   possibleTrip.calcTotalCost()
-  requestEstimateMessage.innerText = `Estimated cost with 10% agent fee: $${possibleTrip.cost}.00`
-  domUpdates.showElement(requestEstimateMessage)
-  setTimeout (function() {
-    domUpdates.hideElement(requestEstimateMessage)
-  }, 3000);
+  if (dateInput.value && numTravelersInput.value && durationInput){
+    requestEstimateMessage.innerText = `Estimated cost with 10% agent fee: $${possibleTrip.cost}.00`
+    domUpdates.showElement(requestEstimateMessage)
+    setTimeout (function() {
+      domUpdates.hideElement(requestEstimateMessage)
+    }, 4000);
+  }
 }
 
 


### PR DESCRIPTION
# Description
Add error handing for getEstimate function, so that estimate does not show until all input fields are filled. 

# Type of change
* [x] New feature (non-breaking change which adds functionality)
* [ ] Troubleshooting or bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause the existing functionality to no longer work as expected)

# How has this been tested?
* [ ] Run the app in the browser using the command `open index.html`
* [ ] Troubleshooting `console.log()`
* [ ] Run the command `npm test` in the terminal
* [ ] Developer Tools

# Checklist
* [ ] I followed the style guidelines.
* [ ] I performed a self-review of my code.
* [ ] I commented on my code, particularly in complex areas.

#Contributors: 
@nvalentini21 
